### PR TITLE
Fix compatibility with React Native

### DIFF
--- a/src/client.jsx
+++ b/src/client.jsx
@@ -67,7 +67,7 @@ class SockJsClient extends React.Component {
   }
 
   render() {
-    return (<div></div>);
+    return null;
   }
 
   _initStompClient = () => {


### PR DESCRIPTION
This change will make the module usable with React Native as well. As per the [docs](https://reactjs.org/docs/react-component.html#render), null is a valid return value for render().