### PR TITLE
update for React 17.x

### DIFF
--- a/src/client.jsx
+++ b/src/client.jsx
@@ -120,7 +120,7 @@ class SockJsClient extends React.Component {
     return false
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.state.connected) {
       // Subscribe to new topics
       Lo.difference(nextProps.topics, this.props.topics)


### PR DESCRIPTION
Using new versions of React, I get this warning:

backend.js:6 Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-async-component-lifecycle-hooks for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: SockJsClient

It's important update the funcions so you can use React 17.x