### PR TITLE
Fix for changing topics

### DIFF
--- a/src/client.jsx
+++ b/src/client.jsx
@@ -178,7 +178,7 @@ class SockJsClient extends React.Component {
 
   _subscribe = (topic) => {
     if (!this.subscriptions.has(topic)) {
-      let subscriptionHeaders = Object.assign(this.props.subscribeHeaders, {id : "sub-" + this.subscriptionIdCounter++});
+      let subscriptionHeaders = Object.assign(this.props.subscribeHeaders, { id: 'sub-' + this.subscriptionIdCounter++ })
       let sub = this.client.subscribe(topic, (msg) => {
         this.props.onMessage(this._processMessage(msg.body), msg.headers.destination)
       }, subscriptionHeaders)

--- a/src/client.jsx
+++ b/src/client.jsx
@@ -196,7 +196,7 @@ class SockJsClient extends React.Component {
 
   _unsubscribe = (topic) => {
     let sub = this.subscriptions.get(topic)
-    sub.unsubscribe(topic)
+    sub.unsubscribe()
     this.subscriptions.delete(topic)
   }
 


### PR DESCRIPTION
Hello Lahsivjar! :) 

I have made this pull request, because i would like to fix one bug, which i found out during working with ,,react-stomp".

This pull request is fixing bug #150. Main reason why this happens is that react-stomp during calling method UNSAFE_componentWillReceiveProps make subscription with XY destination topic and id: **sub-0** then is called  _unsubscribe. What happens when _unsubscribe is called on the stompClient side? StompClient will send unsubscribe request with id: **sub-0**. That means the component unsubscribes older topic and the newest topic, because they have same sub-id. After that when message came from backend side, stompClient will write ,,unhandled message error" to console log (when debug is allowed).

I have changed order of calling subscribe and unsubscribe methods, because that makes more sense to me. Also i have added unique generation of sub-id. This bug is also described here https://stackoverflow.com/questions/60318443/why-all-topics-are-getting-same-id-when-subscribeheaders-is-not-passed-in-props.

Have a nice day!